### PR TITLE
Use new Propel mechanism to load database from script

### DIFF
--- a/Command/ModelBuildCommand.php
+++ b/Command/ModelBuildCommand.php
@@ -50,10 +50,14 @@ class ModelBuildCommand extends WrappedCommand
      */
     protected function getSubCommandArguments(InputInterface $input)
     {
-        $outputDir = $this->getApplication()->getKernel()->getProjectDir().'/';
+        $arguments = [];
+        $arguments['--output-dir'] = $this->getApplication()->getKernel()->getProjectDir().'/';
 
-        return array(
-            '--output-dir' => $outputDir,
-        );
+        $config = $this->getContainer()->getParameter('propel.configuration');
+        if($config['usesDatabaseLoaderScript']) {
+            $arguments['--loader-script-dir'] = $config['paths']['loaderScriptDir'];
+        }
+
+        return $arguments;
     }
 }

--- a/Command/ModelBuildCommand.php
+++ b/Command/ModelBuildCommand.php
@@ -53,13 +53,31 @@ class ModelBuildCommand extends WrappedCommand
         $arguments = [];
         $arguments['--output-dir'] = $this->getApplication()->getKernel()->getProjectDir().'/';
 
-        $container = $this->getContainer();
-        $usesScript = $container->getParameter('propel.usesDatabaseLoaderScript');
+        $usesScript = $this->getContainer()->getParameter('propel.usesDatabaseLoaderScript');
         if($usesScript) {
-            $config = $container->getParameter('propel.configuration');
-            $arguments['--loader-script-dir'] = $config['paths']['loaderScriptDir'];
+            $arguments['--loader-script-dir'] = $this->getLoaderScriptDirectory();
         }
 
         return $arguments;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setupBuildTimeFiles()
+    {
+        parent::setupBuildTimeFiles();
+
+        $loaderScriptDir = $this->getLoaderScriptDirectory();
+        if($loaderScriptDir && !file_exists($loaderScriptDir)) {
+            mkdir(dirname($loaderScriptDir), 0777, true);
+            touch($loaderScriptDir);
+        }
+    }
+
+    protected function getLoaderScriptDirectory(): ?string
+    {
+        $config = $this->getContainer()->getParameter('propel.configuration');
+        return $config['paths']['loaderScriptDir'];
     }
 }

--- a/Command/ModelBuildCommand.php
+++ b/Command/ModelBuildCommand.php
@@ -53,8 +53,10 @@ class ModelBuildCommand extends WrappedCommand
         $arguments = [];
         $arguments['--output-dir'] = $this->getApplication()->getKernel()->getProjectDir().'/';
 
-        $config = $this->getContainer()->getParameter('propel.configuration');
-        if($config['usesDatabaseLoaderScript']) {
+        $container = $this->getContainer();
+        $usesScript = $container->getParameter('propel.usesDatabaseLoaderScript');
+        if($usesScript) {
+            $config = $container->getParameter('propel.configuration');
             $arguments['--loader-script-dir'] = $config['paths']['loaderScriptDir'];
         }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,6 +37,7 @@ class Configuration extends PropelConfiguration
                         ->scalarNode('schemaDir')->defaultValue($this->defaultDir)->end()
                         ->scalarNode('sqlDir')->defaultValue($this->defaultDir.'/sql')->end()
                         ->scalarNode('migrationDir')->defaultValue($this->defaultDir.'/migrations')->end()
+                        ->scalarNode('loaderScriptDir')->defaultValue($this->defaultDir.'/loader')->end()
                         ->scalarNode('composerDir')->defaultNull()->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/PropelExtension.php
+++ b/DependencyInjection/PropelExtension.php
@@ -10,6 +10,7 @@
 
 namespace Propel\Bundle\PropelBundle\DependencyInjection;
 
+use Propel\Runtime\ServiceContainer\StandardServiceContainer;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -45,6 +46,7 @@ class PropelExtension extends Extension
                 $config['generator']['defaultConnection'] = $defaultConnection;
             }
         }
+        $config['usesDatabaseLoaderScript'] = $this->usesDatabaseLoaderScript();
 
         $container->setParameter('propel.logging', $config['runtime']['logging']);
         $container->setParameter('propel.configuration', $config);
@@ -91,5 +93,11 @@ class PropelExtension extends Extension
     public function getAlias()
     {
         return 'propel';
+    }
+
+    public function usesDatabaseLoaderScript(): bool
+    {
+        return (defined(StandardServiceContainer::class . '::CONFIGURATION_VERSION')
+            && StandardServiceContainer::CONFIGURATION_VERSION >= 2);
     }
 }

--- a/DependencyInjection/PropelExtension.php
+++ b/DependencyInjection/PropelExtension.php
@@ -49,7 +49,7 @@ class PropelExtension extends Extension
 
         $container->setParameter('propel.logging', $config['runtime']['logging']);
         $container->setParameter('propel.configuration', $config);
-        $container->setParameter('propel.usesDatabaseLoaderScript') = $this->usesDatabaseLoaderScript();
+        $container->setParameter('propel.usesDatabaseLoaderScript', $this->usesDatabaseLoaderScript());
 
         // Load services
         if (!$container->hasDefinition('propel')) {

--- a/DependencyInjection/PropelExtension.php
+++ b/DependencyInjection/PropelExtension.php
@@ -46,10 +46,10 @@ class PropelExtension extends Extension
                 $config['generator']['defaultConnection'] = $defaultConnection;
             }
         }
-        $config['usesDatabaseLoaderScript'] = $this->usesDatabaseLoaderScript();
 
         $container->setParameter('propel.logging', $config['runtime']['logging']);
         $container->setParameter('propel.configuration', $config);
+        $container->setParameter('propel.usesDatabaseLoaderScript') = $this->usesDatabaseLoaderScript();
 
         // Load services
         if (!$container->hasDefinition('propel')) {

--- a/PropelBundle.php
+++ b/PropelBundle.php
@@ -38,6 +38,8 @@ class PropelBundle extends Bundle
             }
         } catch( \Exception $e ) {
         }
+
+        $this->importDatabaseLoaderScript();
     }
 
     /**
@@ -85,6 +87,22 @@ class PropelBundle extends Bundle
             $serviceContainer->setAdapterClass($name, $config['adapter']);
             $serviceContainer->setConnectionManager($name, $manager);
         }
+    }
+
+    protected function importDatabaseLoaderScript(): bool
+    {
+        $config = $this->container->getParameter('propel.configuration');
+        if(!$config['usesDatabaseLoaderScript']) {
+            return false;
+        }
+        $scriptDir = $config['paths']['loaderScriptDir'];
+        $scriptPath = $scriptDir . '/loadDatabase.php';
+        if(!file_exists($scriptPath)) {
+            throw new \Exception("Database loader script missing at $scriptPath. Please create the file by running propel:model:build");
+        }
+        require_once $scriptPath;
+
+        return true;
     }
 
     protected function configureLogging()

--- a/PropelBundle.php
+++ b/PropelBundle.php
@@ -89,12 +89,18 @@ class PropelBundle extends Bundle
         }
     }
 
+    /**
+     * @throws \Exception
+     *
+     * @return bool Indicates if the script was imported. Needed for testing.
+     */
     protected function importDatabaseLoaderScript(): bool
     {
-        $config = $this->container->getParameter('propel.configuration');
-        if(!$config['usesDatabaseLoaderScript']) {
+        $usesScript = $this->container->getParameter('propel.usesDatabaseLoaderScript');
+        if(!$usesScript) {
             return false;
         }
+        $config = $this->container->getParameter('propel.configuration');
         $scriptDir = $config['paths']['loaderScriptDir'];
         $scriptPath = $scriptDir . '/loadDatabase.php';
         if(!file_exists($scriptPath)) {

--- a/Tests/PropelBundleTest.php
+++ b/Tests/PropelBundleTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of the PropelBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Propel\Bundle\PropelBundle\Tests;
+
+use Exception;
+use Propel\Bundle\PropelBundle\PropelBundle;
+use Propel\Bundle\PropelBundle\Tests\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+
+class PropelBundleTest extends TestCase
+{
+    /**
+     * @dataProvider importDatabaseLoaderScriptDataProvider
+     *
+     * @param bool $usesScript
+     * @param string $loaderScriptDir
+     * @param string $exceptionClass
+     * @param bool $expectedReturn
+     * @param string $message
+     *
+     * @return void
+     */
+    public function testImportDatabaseLoaderScript(
+        bool $usesScript,
+        string $loaderScriptDir,
+        ?string $exceptionClass,
+        ?bool $expectedReturn,
+        string $message
+        )
+    {
+        if($exceptionClass) {
+            $this->expectException($exceptionClass);
+        }
+        $actualReturn = $this->runDatabaseLoaderScriptImport($usesScript, $loaderScriptDir);
+        $this->assertSame($expectedReturn, $actualReturn, $message);
+        
+    }
+
+    public static function importDatabaseLoaderScriptDataProvider(): array
+    {
+        return [
+            // [<uses script>, <script dir>, <exception class>, <expected return>, <message>]
+            [false, '', null, false, 'Should not import script if not set in configuration'],
+            [true, '/this/dir/does/not/exists/bababui/bababui/', Exception::class, null, 'Should throw exception if scritps dir does not exist'],
+            [true, __DIR__ . '/Fixtures', null, true, 'Should import script']
+        ];
+    }
+    
+    public function runDatabaseLoaderScriptImport(bool $usesScirpt, string $loaderScriptDir=''): bool
+    {
+        $bundle = new class() extends PropelBundle{
+            public function runImport(): bool
+            {
+                return $this->importDatabaseLoaderScript();
+            }
+        };
+
+        $config = [
+            'usesDatabaseLoaderScript' => $usesScirpt,
+            'paths' => [
+                'loaderScriptDir' => $loaderScriptDir
+            ]
+        ];
+        
+        $container = new Container();
+        $container->setParameter('propel.configuration', $config);
+        $bundle->setContainer($container);
+
+        return $bundle->runImport();
+    }
+}

--- a/Tests/PropelBundleTest.php
+++ b/Tests/PropelBundleTest.php
@@ -41,7 +41,6 @@ class PropelBundleTest extends TestCase
         }
         $actualReturn = $this->runDatabaseLoaderScriptImport($usesScript, $loaderScriptDir);
         $this->assertSame($expectedReturn, $actualReturn, $message);
-        
     }
 
     public static function importDatabaseLoaderScriptDataProvider(): array
@@ -49,12 +48,12 @@ class PropelBundleTest extends TestCase
         return [
             // [<uses script>, <script dir>, <exception class>, <expected return>, <message>]
             [false, '', null, false, 'Should not import script if not set in configuration'],
-            [true, '/this/dir/does/not/exists/bababui/bababui/', Exception::class, null, 'Should throw exception if scritps dir does not exist'],
+            [true, '/this/dir/does/not/exists/bababui/bababui/', Exception::class, null, 'Should throw exception if scripts dir does not exist'],
             [true, __DIR__ . '/Fixtures', null, true, 'Should import script']
         ];
     }
     
-    public function runDatabaseLoaderScriptImport(bool $usesScirpt, string $loaderScriptDir=''): bool
+    public function runDatabaseLoaderScriptImport(bool $usesScript, string $loaderScriptDir=''): bool
     {
         $bundle = new class() extends PropelBundle{
             public function runImport(): bool
@@ -64,7 +63,6 @@ class PropelBundleTest extends TestCase
         };
 
         $config = [
-            'usesDatabaseLoaderScript' => $usesScirpt,
             'paths' => [
                 'loaderScriptDir' => $loaderScriptDir
             ]
@@ -72,6 +70,7 @@ class PropelBundleTest extends TestCase
         
         $container = new Container();
         $container->setParameter('propel.configuration', $config);
+        $container->setParameter('propel.usesDatabaseLoaderScript', $usesScript);
         $bundle->setContainer($container);
 
         return $bundle->runImport();


### PR DESCRIPTION
This should fix #5 by using the new way Propel loads its database metadata (see [here](https://github.com/propelorm/Propel2/pull/1742)).

It is quite simple:
- when building the `propel-config`, a check is performed if running the loading script is necessary, and a parameter is set accordingly
- a new parameter is added to the configuration loader, which allows to set a path for `loaderScriptDir`
- when running `propel:model:build` and the loading script is needed, the `loaderScriptDir` is passed to the parent command
- when booting PropelBundle and the loading script is needed, it is included from `loaderScriptDir`

I don't use Symfony, so there is some guesswork going on. I have not tested this apart from the existing tests and the one I added. It's probably best if someone else takes over from here. I just wanted to get things started with the new Propel import mechanism, and hope it helps.