### PR TITLE
Fix lint:container

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -31,7 +31,7 @@ abstract class AbstractCommand extends Command
     protected $cacheDir = null;
 
     /**
-     * @var \Symfony\Component\HttpKernel\Bundle\BundleInterface
+     * @var BundleInterface
      */
     protected $bundle = null;
 
@@ -44,6 +44,7 @@ abstract class AbstractCommand extends Command
      * @var OutputInterface
      */
     protected $output;
+
     /**
      * @var ContainerInterface
      */
@@ -51,9 +52,9 @@ abstract class AbstractCommand extends Command
 
     use FormattingHelpers;
 
-    public function __construct(KernelInterface $kernel, $name = null)
+    public function __construct(ContainerInterface $container, $name = null)
     {
-        $this->container = $kernel->getContainer();
+        $this->container = $container;
 
         parent::__construct($name);
     }
@@ -468,6 +469,7 @@ abstract class AbstractCommand extends Command
     protected function getPlatform()
     {
         $config = $this->getContainer()->getParameter('propel.configuration');
+
         return $config['generator']['platformClass'];
     }
 }

--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -51,9 +51,9 @@ abstract class AbstractCommand extends Command
 
     use FormattingHelpers;
 
-    public function __construct(KernelInterface $karnel, $name = null)
+    public function __construct(KernelInterface $kernel, $name = null)
     {
-        $this->container = $karnel->getContainer();
+        $this->container = $kernel->getContainer();
 
         parent::__construct($name);
     }

--- a/Resources/config/console.xml
+++ b/Resources/config/console.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <defaults autowire="true" autoconfigure="true" public="false">
-            <bind key="$kernel" type="service" id="kernel" />
+            <bind key="$container" type="service" id="service_container" />
         </defaults>
         <service id="propel_bundle_propel.command.build_command" class="Propel\Bundle\PropelBundle\Command\BuildCommand">
             <tag name="console.command" command="propel:build" />

--- a/Resources/config/console.xml
+++ b/Resources/config/console.xml
@@ -4,6 +4,9 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <defaults autowire="true" autoconfigure="true" public="false">
+            <bind key="$kernel" type="service" id="kernel" />
+        </defaults>
         <service id="propel_bundle_propel.command.build_command" class="Propel\Bundle\PropelBundle\Command\BuildCommand">
             <tag name="console.command" command="propel:build" />
         </service>

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,4 +7,4 @@ services:
       resource: '../../*'
       ## Resources\skeleton contains not valid php
       ## Twig\Extension\SyntaxExtension.php is defined in Propel.xml
-      exclude: '../../{Propel,Model,Migrations,Tests,Helpers,DependencyInjection,Form,Listener,Validator,Resources/skeleton,Twig/Extension/SyntaxExtension.php,DataCollector,AppBundle.php}'
+      exclude: '../../{Console,Propel,Model,Migrations,Tests,Helpers,DependencyInjection,Form,Listener,Validator,Resources/skeleton,Twig/Extension/SyntaxExtension.php,DataCollector,AppBundle.php}'


### PR DESCRIPTION
@SkyFoxvn using current 5.0 branch, running `bin/console lint:container` on Symfony produces:

```
Invalid definition for service "propel_bundle_propel.command.database_create_command": "Propel\Bundle\PropelBundle\Command\AbstractCommand::__construct()" requires 1 arguments, 0 passed.
```

This PR fixes autowiring for services defined in `Resources/config/console.xml` and fixes this issue.

Best regards