### PR TITLE
Repair propel:fixtures:load

### DIFF
--- a/Command/FixturesLoadCommand.php
+++ b/Command/FixturesLoadCommand.php
@@ -168,7 +168,7 @@ EOT
 
         $datas = $this->getFixtureFiles($type);
 
-        if (count(iterator_to_array($datas)) === 0) {
+        if (count($datas) === 0) {
             return -1;
         }
 
@@ -278,7 +278,7 @@ EOT
      * @param string $in   The directory in which we search the files. If null,
      *                     we'll use the absoluteFixturesPath property.
      *
-     * @return \Iterator An iterator through the files.
+     * @return array The files.
      */
     protected function getFixtureFiles($type = 'sql', $in = null)
     {
@@ -290,17 +290,22 @@ EOT
         $files = $finder->in(null !== $in ? $in : $this->absoluteFixturesPath);
 
         if (null === $this->bundle) {
-            return $files;
+            $finalFixtureFiles = [];
+            foreach ($files as $file) {
+                $finalFixtureFiles[] = new \SplFileInfo($file);
+            }
+
+            return $finalFixtureFiles;
         }
 
-        $finalFixtureFiles = array();
+        $finalFixtureFiles = [];
         foreach ($files as $file) {
             $fixtureFilePath = str_replace($this->getFixturesPath($this->bundle) . DIRECTORY_SEPARATOR, '', $file->getRealPath());
             $logicalName = sprintf('@%s/Resources/fixtures/%s', $this->bundle->getName(), $fixtureFilePath);
             $finalFixtureFiles[] = new \SplFileInfo($this->getFileLocator()->locate($logicalName));
         }
 
-        return new \ArrayIterator($finalFixtureFiles);
+        return $finalFixtureFiles;
     }
 
     /**

--- a/Resources/config/propel.xml
+++ b/Resources/config/propel.xml
@@ -53,7 +53,7 @@
             <argument>%propel.configuration%</argument>
         </service>
 
-        <service id="propel.loader.yaml" class="%propel.loader.yaml.class%">
+        <service id="propel.loader.yaml" class="%propel.loader.yaml.class%" public="true">
             <argument>%kernel.root_dir%</argument>
             <argument>%propel.configuration%</argument>
             <argument type="service" id="faker.generator" on-invalid="null" />


### PR DESCRIPTION
Hi @SkyFoxvn,

Can you please review this? propel:fixtures:load command was broken two times:

```
In Container.php line 275:
                                                                                                                                                                                                                       
  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]                                                                                                                                           
  The "propel.loader.yaml" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.
```

So I make the service public (it requires too much refactoring to inject it properly in FixturesLoadCommand

```
In AbstractDataLoader.php line 49:
                                                                                                                                                                                                                                           
  [TypeError]                                                                                                                                                                                                                              
  Argument 1 passed to Propel\Bundle\PropelBundle\DataFixtures\Loader\AbstractDataLoader::load() must be of the type array, object given, called in /var/www/html/api/vendor/propel/propel-bundle/Command/FixturesLoadCommand.php on line  
   185
```

So I change the return type of FixturesLoadCommand::getFixtureFiles to make it compatible again with AbstractDataLoader::load.

This was broken by commit 3b1a5c5f2b408574f25d4fb98bb032e86ca481c0

Thanks!