### PR TITLE
Fix compatibility with Propel master.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration extends PropelConfiguration
         $this->kernelDir = $kernelDir;
     }
 
-    protected function addPathsSection(ArrayNodeDefinition $node)
+    protected function addPathsSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()
@@ -47,7 +47,7 @@ class Configuration extends PropelConfiguration
         ;
     }
 
-    protected function addRuntimeSection(ArrayNodeDefinition $node)
+    protected function addRuntimeSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()
@@ -115,7 +115,7 @@ class Configuration extends PropelConfiguration
             ->end();
     }
 
-    protected function addDatabaseSection(ArrayNodeDefinition $node)
+    protected function addDatabaseSection(ArrayNodeDefinition $node): void
     {
         $validAdapters = array('mysql', 'pgsql', 'sqlite', 'mssql', 'sqlsrv', 'oracle');
 

--- a/PropelBundle.php
+++ b/PropelBundle.php
@@ -78,12 +78,12 @@ class PropelBundle extends Bundle
 
                 $manager->setReadConfiguration($slaveConnections);
             } else {
-                $manager = new ConnectionManagerSingle();
+                $manager = new ConnectionManagerSingle($name);
                 $manager->setConfiguration($connection);
             }
 
             $serviceContainer->setAdapterClass($name, $connection['adapter']);
-            $serviceContainer->setConnectionManager($name, $manager);
+            $serviceContainer->setConnectionManager($manager);
 
             // load database maps
             if(file_exists($config['paths']['loaderScriptDir'].'/loadDatabase.php') && is_readable($config['paths']['loaderScriptDir'].'/loadDatabase.php')) {

--- a/Tests/Fixtures/Model/Base/BookQuery.php
+++ b/Tests/Fixtures/Model/Base/BookQuery.php
@@ -418,7 +418,7 @@ abstract class BookQuery extends ModelCriteria
      * @param  ConnectionInterface $con the connection to use
      * @return int                 The number of affected rows (if supported by underlying database driver).
      */
-    public function doDeleteAll(ConnectionInterface $con = null)
+    public function doDeleteAll(ConnectionInterface $con = null): int
     {
         if (null === $con) {
             $con = Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME);
@@ -455,7 +455,7 @@ abstract class BookQuery extends ModelCriteria
      * @throws PropelException     Any exceptions caught during processing will be
      *                                    rethrown wrapped into a PropelException.
      */
-     public function delete(ConnectionInterface $con = null)
+     public function delete(ConnectionInterface $con = null): int
      {
         if (null === $con) {
             $con = Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME);

--- a/Tests/Fixtures/Model/Map/BookTableMap.php
+++ b/Tests/Fixtures/Model/Map/BookTableMap.php
@@ -133,7 +133,7 @@ class BookTableMap extends TableMap
      * @return void
      * @throws PropelException
      */
-    public function initialize()
+    public function initialize(): void
     {
         // attributes
         $this->setName('book');
@@ -152,7 +152,7 @@ class BookTableMap extends TableMap
     /**
      * Build the RelationMap objects for this table relationships
      */
-    public function buildRelations()
+    public function buildRelations(): void
     {
     } // buildRelations()
 


### PR DESCRIPTION
We had:

```
Compile Error: Declaration of Propel\Bundle\PropelBundle\DependencyInjection\Configuration::addPathsSection(Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node) must be compatible with Propel\Common\Config\PropelConfiguration::addPathsSection(Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node): void

Compile Error: Declaration of Propel\Bundle\PropelBundle\DependencyInjection\Configuration::addDatabaseSection(Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node) must be compatible with Propel\Common\Config\PropelConfiguration::addDatabaseSection(Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node): void

Symfony\Component\Debug\Exception\FatalThrowableError^ {#33
  -originalClassName: "ArgumentCountError"
  #message: "Too few arguments to function Propel\Runtime\Connection\ConnectionManagerSingle::__construct(), 0 passed in /var/www/html/vendor/skyfox/propel-bundle/PropelBundle.php on line 81 and exactly 1 expected"
  #code: 0
  #file: "./vendor/propel/propel/src/Propel/Runtime/Connection/ConnectionManagerSingle.php"
```