### PR TITLE
fix: missing return added

### DIFF
--- a/Command/SqlInsertCommand.php
+++ b/Command/SqlInsertCommand.php
@@ -47,7 +47,7 @@ class SqlInsertCommand extends WrappedCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if ($input->getOption('force')) {
-            parent::execute($input, $output);
+            return parent::execute($input, $output);
         } else {
             $output->writeln('<error>You have to use --force to execute all SQL statements.</error>');
             return 1;


### PR DESCRIPTION
Hi!

I've noticed that in one command `propel:sql:insert` is missing a `return` statement which causes an exception, so I've added it. 