### PR TITLE
Fix propel datacollector

### DIFF
--- a/DataCollector/PropelDataCollector.php
+++ b/DataCollector/PropelDataCollector.php
@@ -93,7 +93,7 @@ class PropelDataCollector extends DataCollector
      */
     private function buildQueries(): array
     {
-        return $this->logger->getQueries();
+        return iterator_to_array($this->data['queries'], false);
     }
 
     /**

--- a/DataCollector/PropelDataCollector.php
+++ b/DataCollector/PropelDataCollector.php
@@ -93,7 +93,7 @@ class PropelDataCollector extends DataCollector
      */
     private function buildQueries(): array
     {
-        return iterator_to_array($this->data['queries'], false);
+        return $this->logger->getQueries();
     }
 
     /**

--- a/DataCollector/PropelDataCollector.php
+++ b/DataCollector/PropelDataCollector.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\VarDumper\Caster\TraceStub;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
  * The PropelDataCollector collector class collects information.
@@ -54,11 +55,11 @@ class PropelDataCollector extends DataCollector
     /**
      * Returns queries.
      *
-     * @return array<int, array{sql: string, connection: string, time: int|float, memory: int, trace: TraceStub}> Queries
+     * @return Data<int, array{sql: string, connection: string, time: int|float, memory: int, trace: TraceStub}> Queries
      */
-    public function getQueries(): array
+    public function getQueries(): Data
     {
-        return iterator_to_array($this->data['queries'], false);
+        return $this->data['queries'];
     }
 
     /**

--- a/DataCollector/PropelDataCollector.php
+++ b/DataCollector/PropelDataCollector.php
@@ -58,7 +58,7 @@ class PropelDataCollector extends DataCollector
      */
     public function getQueries(): array
     {
-        return $this->data['queries'];
+        return iterator_to_array($this->data['queries'], false);
     }
 
     /**


### PR DESCRIPTION
Fix error in profiler on the Propel panel

```
An exception has been thrown during the rendering of a template ("Propel\Bundle\PropelBundle\DataCollector\PropelDataCollector::getQueries(): Return value must be of type array, Symfony\Component\VarDumper\Cloner\Data returned").
```