### PR TITLE
Add uuidColumnType

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -222,6 +222,7 @@ class Configuration extends PropelConfiguration
                                     ->children()
                                         ->scalarNode('tableType')->defaultValue('InnoDB')->treatNullLike('InnoDB')->end()
                                         ->scalarNode('tableEngineKeyword')->defaultValue('ENGINE')->end()
+                                        ->scalarNode('uuidColumnType')->defaultValue('binary')->end()
                                     ->end()
                                 ->end()
                                 ->arrayNode('sqlite')


### PR DESCRIPTION
Please allow propel bundle to use the uuidColumnType configuration

It was added 2 years ago in Propel2 : https://github.com/propelorm/Propel2/pull/1924