### PR TITLE
remove double php version from ci matrix

### DIFF
--- a/.github/workflows/CI 7.0.yml
+++ b/.github/workflows/CI 7.0.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.0.2', '8.1', '8.1', '8.2', '8.3' ]
+        php-version: [ '8.0.2', '8.1', '8.2', '8.3' ]
         symfony-version: [ '6.0', '6.1', '6.2', '6.3', '6.4', '7.0', '7.1' ]
     steps:
       - name: Setup PHP, with composer and extensions


### PR DESCRIPTION
PHP 8.1 was listed twice in the CI matrix.

Tagging @SkyFoxvn 