### PR TITLE
remove symfony from test matrix

### DIFF
--- a/.github/workflows/CI 7.0.yml
+++ b/.github/workflows/CI 7.0.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [ '8.0.2', '8.1', '8.2', '8.3' ]
-        symfony-version: [ '6.0', '6.1', '6.2', '6.3', '6.4', '7.0', '7.1' ]
     steps:
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2
@@ -42,7 +41,7 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Composer update (Symfony version ${{ matrix.symfony-version }})
+      - name: Composer update
         run: composer install --prefer-dist --no-interaction
 
       - name: Run tests >= 8.1


### PR DESCRIPTION
The `symfony-version` list in the CI test matrix had no effect.
These versions are not passed to Composer. Composer just installed the latest possible version available for each PHP version.
So this PR doesn't really change anything. It just removes the illusion that different Symfony versions where tested.

Propel itself solves this with multiple composer.json files it moves to the project root during test runs. Each composer.json just allowing one Symfony version. I didn't opt for that solution (yet) as it is not very maintainable. I also didn't find a better way (yet). But in the meanwhile I suggest to remove this with the minor benefit test runs are shorter (for now).

Tagging @SkyFoxvn 